### PR TITLE
Create GitHub action to clear Cloudflare cache

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,18 @@
+name: Deploy my website
+on:
+  push:
+    branches:
+      - production
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+    # Put steps here to build your site, deploy it to a service, etc.
+
+    - name: Purge cache
+      uses: jakejarvis/cloudflare-purge-action@master
+      env:
+        CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
+        CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}


### PR DESCRIPTION
Cloudflare caches static files so changes you make to the website won't
be visible on the website. Cloudflare will continue to serve the cached
files not the updated files.

This GitHub action clears the Cloudflare cache everytime you push to
production.